### PR TITLE
Solve n+1 queries problem in user feed

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -229,6 +229,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-20
+  x86_64-darwin-21
 
 DEPENDENCIES
   bootsnap (>= 1.4.4)

--- a/app/controllers/api/scores_controller.rb
+++ b/app/controllers/api/scores_controller.rb
@@ -5,7 +5,7 @@ module Api
     before_action :validate_score_user_id, only: :destroy
 
     def user_feed
-      scores = Score.all.order(played_at: :desc, id: :desc)
+      scores = Score.all.order(played_at: :desc, id: :desc).includes(:user)
       serialized_scores = scores.map(&:serialize)
 
       response = {


### PR DESCRIPTION
Fixes: [Improve scores feed performance #1](https://github.com/AACraiu/golfr_backend/issues/1#issue-1051727798)

**Changes**

Changed from lazy loading in user_feed method to eager loading to prevent making a separate database query for each score in a user's feed.

**Before**

Making n+1 queries, one for each user.

<img width="833" alt="Screenshot 2022-12-12 at 13 14 42" src="https://user-images.githubusercontent.com/118809326/207031750-6469d411-a6de-41d2-a0c8-ce0124cb3ec2.png">


**After**

Getting all users at once with a single query.

<img width="846" alt="Screenshot 2022-12-12 at 13 12 44" src="https://user-images.githubusercontent.com/118809326/207031499-371d60ab-1ab7-4331-9971-f4fd964f9fa5.png">


