### PR TITLE
add limit to user feed

### DIFF
--- a/app/controllers/api/scores_controller.rb
+++ b/app/controllers/api/scores_controller.rb
@@ -5,7 +5,7 @@ module Api
     before_action :validate_score_user_id, only: :destroy
 
     def user_feed
-      scores = Score.all.order(played_at: :desc, id: :desc)
+      scores = Score.all.order(played_at: :desc, id: :desc).last(25)
       serialized_scores = scores.map(&:serialize)
 
       response = {

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -29,11 +29,11 @@ User.create!(
 rng = Random.new
 now = Time.zone.today
 User.all.each do |user|
-  5.times do |i|
+  50.times do |i|
     Score.create!(
       user: user,
       total_score: rng.rand(66..99),
-      played_at: now - 5.days + i.days
+      played_at: now - 50.days + i.days
     )
   end
 end

--- a/spec/controllers/api/scores_controller_spec.rb
+++ b/spec/controllers/api/scores_controller_spec.rb
@@ -26,6 +26,19 @@ describe Api::ScoresController, type: :request do
       expect(scores[1]['total_score']).to eq 68
       expect(scores[2]['total_score']).to eq 79
     end
+
+    it 'it should return maximum 25 scores' do
+      30.times do
+        create(:score, user: @user1, total_score: 68, played_at: '2021-06-13')
+      end
+      get api_feed_path
+
+      expect(response).to have_http_status(:ok)
+      response_hash = JSON.parse(response.body)
+      scores = response_hash['scores']
+
+      expect(scores.size).to eq 25
+    end
   end
 
   describe 'POST create' do


### PR DESCRIPTION
Fixes: [Limit the number of scores in the feed #21](https://github.com/AACraiu/golfr_backend/issues/21)

**Changes**

Add limit of 25 to `user_feed`.
Changed database seed to 50 instead of 5 to test that it only returns 25 scores.
Add a test that verifies that the feed has maximum 25 scores.

**Before**

<img width="850" alt="Screenshot 2022-12-13 at 17 08 37" src="https://user-images.githubusercontent.com/118809326/207372931-86a96e14-9816-4fe3-9c78-6e73d34c3bcd.png">


**After**

<img width="850" alt="Screenshot 2022-12-13 at 17 08 56" src="https://user-images.githubusercontent.com/118809326/207372995-747cfc77-d1f5-41fd-988d-37209a79f932.png">


